### PR TITLE
Guard mas and az upgrades with existence checks and || true

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -73,8 +73,8 @@ fi
 brew bundle -v
 brew cleanup
 brew doctor -v || true
-mas upgrade
-az upgrade --yes
+if command -v mas &>/dev/null; then mas upgrade || true; fi
+if command -v az &>/dev/null; then az upgrade --yes || true; fi
 
 # --- Mackup ---
 if [[ "$mode" == "init" ]]; then


### PR DESCRIPTION
## Summary
- Adds `command -v` existence checks before running `mas upgrade` and `az upgrade --yes`, so the script degrades gracefully when either tool is not installed.
- Appends `|| true` to both commands to prevent `set -e` from aborting the script on benign non-zero exits (e.g., no updates available).
- Consistent with the existing `brew doctor -v || true` pattern on the preceding line.