### PR TITLE
Add tool existence checks and remove stale .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 Brewfile.backup
 Brewfile.lock.json
 .Brewfile.lock.json.icloud
-backup_npmrc
-initial_setup.sh

--- a/update.sh
+++ b/update.sh
@@ -21,6 +21,14 @@ case "$1" in
   *)        usage ;;
 esac
 
+# --- Verify required tools ---
+for tool in brew git; do
+  if ! command -v "$tool" &>/dev/null; then
+    echo "Error: '$tool' is required but not installed."
+    exit 1
+  fi
+done
+
 # --- Git branching (update mode only) ---
 now=$(date '+%Y%m%d')
 if [[ "$mode" == "update" ]]; then
@@ -77,7 +85,9 @@ if command -v mas &>/dev/null; then mas upgrade || true; fi
 if command -v az &>/dev/null; then az upgrade --yes || true; fi
 
 # --- Mackup ---
-if [[ "$mode" == "init" ]]; then
+if ! command -v mackup &>/dev/null; then
+  echo "Warning: mackup not found, skipping settings backup/restore."
+elif [[ "$mode" == "init" ]]; then
   mackup restore
 else
   mackup backup -f


### PR DESCRIPTION
## Summary
- **Tool existence checks (High #2):** Adds upfront validation that `brew` and `git` are installed before the script does any work. Wraps the `mackup` block in a `command -v` guard that prints a warning and skips settings backup/restore if mackup is not installed. This complements the `mas` and `az` guards added in PR #22.
- **Clean up .gitignore (High #3):** Removes stale entries for `backup_npmrc` and `initial_setup.sh` — neither file exists on disk or in the repository.