### PR TITLE
Add --dry-run flag and concurrent run protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Run with `--update` every couple of weeks to keep everything current:
 ./update.sh --update
 ```
 
+Add `--dry-run` to preview what would be executed without making any changes:
+
+```bash
+./update.sh --update --dry-run
+```
+
 ### What it does
 
 1. Checks out `main` and pulls latest changes
@@ -69,6 +75,7 @@ The script is designed to be re-run safely on the same day. If it fails partway 
 - Most update commands are idempotent
 - Commits are amended and force-pushed rather than stacked
 - PR creation is skipped if one already exists for the branch
+- A lock file (`/tmp/update.sh.lock`) prevents concurrent runs
 
 ## Personalizing your fork
 

--- a/update.sh
+++ b/update.sh
@@ -2,26 +2,56 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: ./update.sh [--init | --update]"
+  echo "Usage: ./update.sh [--init | --update] [--dry-run]"
   echo ""
-  echo "  --init    Initial setup for a new Mac. Installs everything from the"
-  echo "            Brewfile and restores app settings via Mackup."
-  echo "  --update  Periodic update. Upgrades packages, snapshots the Brewfile,"
-  echo "            and commits changes via GitHub PR."
+  echo "  --init      Initial setup for a new Mac. Installs everything from the"
+  echo "              Brewfile and restores app settings via Mackup."
+  echo "  --update    Periodic update. Upgrades packages, snapshots the Brewfile,"
+  echo "              and commits changes via GitHub PR."
+  echo "  --dry-run   Preview what would be executed without making any changes."
   exit 1
 }
 
 step() { echo ""; echo "==> $1"; }
 
-if [[ $# -ne 1 ]]; then
+dry_run=false
+mode=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --init)    mode="init" ;;
+    --update)  mode="update" ;;
+    --dry-run) dry_run=true ;;
+    *)         usage ;;
+  esac
+done
+
+if [[ -z "$mode" ]]; then
   usage
 fi
 
-case "$1" in
-  --init)   mode="init" ;;
-  --update) mode="update" ;;
-  *)        usage ;;
-esac
+run() {
+  if [[ "$dry_run" == true ]]; then
+    echo "[dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+# --- Prevent concurrent runs ---
+LOCK_FILE="/tmp/update.sh.lock"
+if [[ -f "$LOCK_FILE" ]]; then
+  existing_pid=$(cat "$LOCK_FILE")
+  if kill -0 "$existing_pid" 2>/dev/null; then
+    echo "Error: Another instance is already running (PID $existing_pid)."
+    exit 1
+  else
+    echo "Warning: Removing stale lock file from PID $existing_pid."
+    rm -f "$LOCK_FILE"
+  fi
+fi
+echo $$ > "$LOCK_FILE"
+trap 'rm -f "$LOCK_FILE"' EXIT
 
 # --- Verify required tools ---
 step "Verifying required tools"
@@ -42,27 +72,31 @@ if [[ "$mode" == "update" ]]; then
     exit 1
   fi
 
-  git checkout main
-  git pull origin main
-  git fetch --prune
+  run git checkout main
+  run git pull origin main
+  run git fetch --prune
 
   # Clean up local branches already merged into main
   for branch in $(git branch --merged main | grep -v '^\*\|main'); do
-    git branch -d "$branch" 2>/dev/null || true
+    run git branch -d "$branch" 2>/dev/null || true
   done
 
-  if git show-ref --verify --quiet "refs/heads/$now"; then
-    git checkout "$now"
+  if [[ "$dry_run" == false ]]; then
+    if git show-ref --verify --quiet "refs/heads/$now"; then
+      git checkout "$now"
+    else
+      git checkout -b "$now"
+    fi
   else
-    git checkout -b "$now"
+    echo "[dry-run] git checkout -b $now"
   fi
 fi
 
 # --- System and package updates ---
 step "Running macOS software update"
-sudo softwareupdate -ia --verbose
+run sudo softwareupdate -ia --verbose
 step "Updating Homebrew"
-brew update
+run brew update
 
 # Untap deprecated taps
 step "Checking for deprecated taps"
@@ -73,7 +107,10 @@ deprecated_taps=$(brew tap 2>/dev/null | while read -r t; do
 done)
 if [[ -n "$deprecated_taps" ]]; then
   echo "Untapping deprecated taps: $deprecated_taps"
-  echo "$deprecated_taps" | xargs -n1 brew untap
+  while read -r tap; do
+    [[ -n "$tap" ]] || continue
+    run brew untap "$tap"
+  done <<< "$deprecated_taps"
 fi
 
 # Uninstall deprecated formulae
@@ -81,75 +118,82 @@ step "Checking for deprecated formulae"
 while read -r formula; do
   [[ -n "$formula" ]] || continue
   echo "Uninstalling deprecated formula: $formula"
-  brew uninstall --ignore-dependencies "$formula"
+  run brew uninstall --ignore-dependencies "$formula"
 done < <(brew info --installed --json=v2 2>/dev/null \
   | python3 -c "import sys,json;[print(f['full_name']) for f in json.load(sys.stdin).get('formulae',[]) if f.get('deprecated')]")
 
 step "Upgrading Homebrew packages"
-brew upgrade
+run brew upgrade
 
 # Snapshot current state before installing (update mode only)
 if [[ "$mode" == "update" ]]; then
   step "Snapshotting Brewfile"
-  brew bundle dump -f
+  run brew bundle dump -f
 fi
 
 step "Installing from Brewfile"
-brew bundle -v
+run brew bundle -v
 step "Cleaning up Homebrew"
-brew cleanup
-brew doctor -v || true
+run brew cleanup
+run brew doctor -v || true
 step "Upgrading other package managers"
-if command -v mas &>/dev/null; then mas upgrade || true; fi
-if command -v az &>/dev/null; then az upgrade --yes || true; fi
+if command -v mas &>/dev/null; then run mas upgrade || true; fi
+if command -v az &>/dev/null; then run az upgrade --yes || true; fi
 
 # --- Mackup ---
 step "Managing application settings via Mackup"
 if ! command -v mackup &>/dev/null; then
   echo "Warning: mackup not found, skipping settings backup/restore."
 elif [[ "$mode" == "init" ]]; then
-  mackup restore
+  run mackup restore
 else
-  mackup backup -f
+  run mackup backup -f
 fi
 
 # --- Git commit and PR (update mode only) ---
 if [[ "$mode" == "update" ]]; then
   step "Committing and creating PR"
-  # Stage and commit if there are uncommitted changes
-  if ! git diff --quiet || ! git diff --cached --quiet; then
-    git add .
-    if git log main.."$now" --oneline | grep -q .; then
-      git commit --amend -m "ran update on $now"
-    else
-      git commit -m "ran update on $now"
+  if [[ "$dry_run" == true ]]; then
+    echo "[dry-run] git add . && git commit -m 'ran update on $now'"
+    echo "[dry-run] git push origin $now"
+    echo "[dry-run] gh pr create --fill -B main"
+    echo "[dry-run] gh pr merge --admin --squash --delete-branch"
+  else
+    # Stage and commit if there are uncommitted changes
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+      git add .
+      if git log main.."$now" --oneline | grep -q .; then
+        git commit --amend -m "ran update on $now"
+      else
+        git commit -m "ran update on $now"
+      fi
     fi
-  fi
 
-  # Check if the branch has any commits beyond main
-  if ! git log main.."$now" --oneline | grep -q .; then
-    echo "No changes to commit."
+    # Check if the branch has any commits beyond main
+    if ! git log main.."$now" --oneline | grep -q .; then
+      echo "No changes to commit."
+      git checkout main
+      git branch -d "$now" 2>/dev/null || true
+      exit 0
+    fi
+
+    # Push the branch
+    if git ls-remote --heads origin "$now" | grep -q .; then
+      git push --force-with-lease origin "$now"
+    else
+      git push --set-upstream origin "$now"
+    fi
+
+    # Create or find existing PR, then merge
+    if ! gh pr view "$now" &>/dev/null; then
+      pr_url=$(gh pr create --fill -B "main")
+    else
+      pr_url=$(gh pr view "$now" --json url -q '.url')
+    fi
+    gh pr merge "$pr_url" --admin --squash --delete-branch
     git checkout main
+    git pull origin main
     git branch -d "$now" 2>/dev/null || true
-    exit 0
   fi
-
-  # Push the branch
-  if git ls-remote --heads origin "$now" | grep -q .; then
-    git push --force-with-lease origin "$now"
-  else
-    git push --set-upstream origin "$now"
-  fi
-
-  # Create or find existing PR, then merge
-  if ! gh pr view "$now" &>/dev/null; then
-    pr_url=$(gh pr create --fill -B "main")
-  else
-    pr_url=$(gh pr view "$now" --json url -q '.url')
-  fi
-  gh pr merge "$pr_url" --admin --squash --delete-branch
-  git checkout main
-  git pull origin main
-  git branch -d "$now" 2>/dev/null || true
 fi
 


### PR DESCRIPTION
## Summary

Implements the remaining low priority improvements:

- **`--dry-run` flag (#8):** Adds a `run()` wrapper function. In dry-run mode, destructive commands print `[dry-run] <command>` instead of executing. Read-only checks (tool detection, `gh auth status`, etc.) still run so the preview is accurate. Usage: `./update.sh --update --dry-run`
- **Concurrent run protection (#9):** Uses a PID-based lock file at `/tmp/update.sh.lock`. If another instance is running, the script exits with an error. Stale lock files from crashed runs are detected and cleaned up automatically. A `trap EXIT` ensures the lock is removed on both success and failure.
- **README updates:** Documents the `--dry-run` flag and lock file behavior.
- **Shellcheck fix:** Replaced `xargs -n1 run brew untap` (shell functions can't be passed to xargs) with a `while read` loop.

Note: Stale local branches and the orphaned `master` branch were cleaned up directly (not part of this PR).